### PR TITLE
updated environment ymls to include pyahocorasick and updated effect size estimation with new math

### DIFF
--- a/envs/VFFenv_dev_240702.yml
+++ b/envs/VFFenv_dev_240702.yml
@@ -19,6 +19,7 @@ dependencies:
   - bowtie2>=2.4.2
   - samtools>=1.11
   - crispresso2>=2.2.6
+  - pyahocorasick>=2.1.0 #added 070224 for dealing with reads that have multiple edits
   - r-base>=3.6.3
   - r-optparse=1.6.2 # pinned
   - r-tidyr>=0.8.3

--- a/envs/VFFenv_release_240702.yml
+++ b/envs/VFFenv_release_240702.yml
@@ -474,3 +474,4 @@ dependencies:
   - zipp=3.17.0=pyhd8ed1ab_0
   - zlib=1.2.13=hd590300_5
   - zstd=1.5.5=hfc55251_0
+  - pyahocorasick=2.1.0

--- a/workflow/rules/estimate_effect_sizes.smk
+++ b/workflow/rules/estimate_effect_sizes.smk
@@ -111,9 +111,20 @@ rule aggregate_allelic_effects:
         lambda wildcards: 
         	['results/{dir}/{e}.effects_vs_ref_ignoreInputBin.txt'.format(dir=wildcards.replicateDirectory, e=e) for e in samplesheet.loc[samplesheet['Bin'].isin(binList),wildcards.ExperimentID].drop_duplicates()]
     output:
-        flat='results/summary/V1_AllelicEffects.{replicateDirectory}.{ExperimentID}.flat.tsv.gz'
+        flat='results/summary/AllelicEffects.{replicateDirectory}.{ExperimentID}.flat.tsv.gz'
     run:
-        aggregate_allelic_effect_tables(samplesheet, output.flat, wildcards) 
+        aggregate_allelic_effect_tables(samplesheet, output.flat, wildcards)
+
+# need to specifically rename the by experiment rep file, but not by pcr rep file
+rule rename_V1_allelic_effects:
+	input:
+		'results/summary/AllelicEffects.byExperimentRep.ExperimentIDReplicates.flat.tsv.gz'
+	output:
+		'results/summary/V1_AllelicEffects.byExperimentRep.ExperimentIDReplicates.flat.tsv.gz'
+	run:
+		import os
+	        os.rename(input[0], output[0])
+
 
 # V2 of effect size normalization
 rule normalize_allelic_effect_sizes_V2:

--- a/workflow/rules/estimate_effect_sizes.smk
+++ b/workflow/rules/estimate_effect_sizes.smk
@@ -111,10 +111,22 @@ rule aggregate_allelic_effects:
         lambda wildcards: 
         	['results/{dir}/{e}.effects_vs_ref_ignoreInputBin.txt'.format(dir=wildcards.replicateDirectory, e=e) for e in samplesheet.loc[samplesheet['Bin'].isin(binList),wildcards.ExperimentID].drop_duplicates()]
     output:
-        flat='results/summary/AllelicEffects.{replicateDirectory}.{ExperimentID}.flat.tsv.gz'
+        flat='results/summary/V1_AllelicEffects.{replicateDirectory}.{ExperimentID}.flat.tsv.gz'
     run:
         aggregate_allelic_effect_tables(samplesheet, output.flat, wildcards) 
 
+# V2 of effect size normalization
+rule normalize_allelic_effect_sizes_V2:
+	input:
+		'results/summary/V1_AllelicEffects.byExperimentRep.ExperimentIDReplicates.flat.tsv.gz'
+	output:
+		'results/summary/AllelicEffects.byExperimentRep.ExperimentIDReplicates.flat.tsv.gz'
+	params:
+		codedir=config['codedir']
+	shell:
+		"""
+		python {params.codedir}/workflow/scripts/V2_effect_size_adjustment.py {input} {output}
+		"""
 
 ###################################################################################
 ## Run again, but ignore input bin counts

--- a/workflow/scripts/V2_effect_size_adjustment.py
+++ b/workflow/scripts/V2_effect_size_adjustment.py
@@ -1,0 +1,76 @@
+#! /usr/bin/env python
+
+import pandas as pd
+import numpy as np
+import argparse
+
+def adjust_effects_heterozygous_editing_V2(effects_table, output_file):
+	
+	#read in V1 effect size table
+	effects_table = pd.read_table(effects_table, compression='gzip')	
+
+	# remove WT alleles, we dont need them for this 
+	effects_table = effects_table[effects_table['RefAllele'] != True]
+	# set threshold for frequency of edits in the population that we trust effect sizes for
+	effects_table = effects_table[effects_table['freq'] >= 0.0001] 
+
+	# set variables
+	loops = 0 # counter
+	thres = 0.001 # threshold for expectation maximization. Once met it will break the loop
+	effects_table.rename(columns={'effect_size': 'V1_effect_size'}, inplace=True) # rename the initial MLE effect size column so it doesnt get overwritten
+	effects_table['effect_size_updated'] = effects_table['effect_size_scaled_qpcr'] -1 # ni in the space of the z0, the measured effect from original MLE scaled for qPCR, or e_new
+	effects_table['effect_size_eold'] = -0.20 # random number, here just starting with 0. this is the e_old
+	while ((effects_table['effect_size_eold'] - effects_table['effect_size_updated'])**2).mean() > thres:
+		effects_table['effect_size_eold'] = effects_table['effect_size_updated'] # setting for each loop iteration, e_old=e_new
+
+		# Step 1: Calculate WT_drag_contribution and ref_allele_contribution for each row
+		effects_table['WT_drag_contribution'] = (effects_table['guide_freq'] * (1 - effects_table['adjusted_freq'])) * (1 + (effects_table['effect_size_eold'] * effects_table['adjusted_freq']) / 2) #will sum these in next step
+		effects_table['ref_allele_contribution'] = effects_table['guide_freq'] * (1 - effects_table['adjusted_freq']) #will sum these in next step
+
+		# Step 2: Calculate WT_drag_contribution_summed, f_0, and d for each sample without using groupby
+		unique_combinations = effects_table[['BioRep', 'FFRep']].drop_duplicates()
+		for index, row in unique_combinations.iterrows():
+			BioRep = row['BioRep']
+			FFRep = row['FFRep']
+			# Create subset DataFrame for the current BioRep and FFRep combination
+			subset_df = effects_table[(effects_table['BioRep'] == BioRep) & (effects_table['FFRep'] == FFRep)].copy()
+			# Calculate WT_drag_contribution_summed for the subset
+			WT_drag_contribution_summed = subset_df['WT_drag_contribution'].sum()
+			# Calculate f_0 for the subset
+			f_0 = subset_df['ref_allele_contribution'].sum()
+			# Calculate d for the subset
+			d = WT_drag_contribution_summed / f_0 # This is d per FF/BioRep
+			effects_table.loc[(effects_table['BioRep'] == BioRep) & (effects_table['FFRep'] == FFRep), 'd'] = d
+			print(subset_df)
+		# Step 3: Calculate effect_size_updated for all rows -this is ei or e_new for next iteration or until the loop breaks
+		effects_table['effect_size_updated'] = (2 * (effects_table['d'] * effects_table['effect_size_scaled_qpcr'] - 1)) / (1 + effects_table['adjusted_freq'])
+		loops += 1
+		print(loops)
+
+	effects_table['effect_size_updated'] = effects_table['effect_size_updated'] + 1 # revert to where 1 = no effect
+	effects_table = effects_table.rename(columns={'effect_size_updated': 'effect_size'}) # rename this as effect_size to be reported
+
+	# drop columns that are not needed - initial effect size (no adjustment) and effect_size_scaled_qpcr (with old adjustments) can be found in the V1 allelic effect size output file
+	columns_to_drop = [
+	    'initial_effect_size',
+	    'effect_size_scaled_qpcr',
+	    'V1_effect_size',
+	    'effect_size_eold',
+	    'WT_drag_contribution',
+	    'ref_allele_contribution',
+	    'd'
+	]
+	effects_table = effects_table.drop(columns=columns_to_drop)
+
+
+	effects_table.to_csv(output_file, sep='\t', index=False)
+	return output_file
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Process input file for adjusting effects.')
+    parser.add_argument('effects_table', type=str, help='Path to input file (TSV format)')
+    parser.add_argument('output_file', type=str, help='Path to output file (TSV format)')
+
+
+    args = parser.parse_args()
+    adjust_effects_heterozygous_editing_V2(args.effects_table, args.output_file)


### PR DESCRIPTION
Previous changes to the repo for dropping multi-edit reads requirs pyahocorasick for parsing reads. We have updated our environment yaml files to include this package.

We updated our effect size estimation code with a new heterozygous editing adjustment. Specifically, we added a new rule to the estimate_effect_sizes.smk file that uses V2_effect_size_adjustment.py to calculate updated effect sizes, which are output to results/summary/AllelicEffects.byExperimentRep.ExperimentIDReplicates.flat.tsv.gz. Effect sizes calculated with version 1 of the heterozygous editing adjustment can be found in results/summary/V1_AllelicEffects.byExperimentRep.ExperimentIDReplicates.flat.tsv.gz